### PR TITLE
売上DBチューニングに伴う変更

### DIFF
--- a/src/main/java/dao/OrderDAO.java
+++ b/src/main/java/dao/OrderDAO.java
@@ -17,13 +17,12 @@ public class OrderDAO extends DAO {
 
 		PreparedStatement st;
 		st=con.prepareStatement(
-			"SELECT C.PROCEEDS_ID, C.DATE, M.SIMEI, C.CHARGE_ID, C.TOTALPRICE, P.NAME, P.PRICE, O.COUNT FROM PROCEEDS AS C JOIN PURCHASE AS O ON C.CHARGE_ID = O.CHARGE_ID JOIN FARMPRODUCT AS P ON O.PRODUCT_ID = P.PRODUCT_ID JOIN MEMBER AS M ON C.MEMBER_ID = M.MEMBER_ID;"
+			"SELECT C.DATE, M.SIMEI, C.CHARGE_ID, C.TOTALPRICE, P.NAME, P.PRICE, O.COUNT FROM PROCEEDS AS C JOIN PURCHASE AS O ON C.CHARGE_ID = O.CHARGE_ID JOIN FARMPRODUCT AS P ON O.PRODUCT_ID = P.PRODUCT_ID JOIN MEMBER AS M ON C.MEMBER_ID = M.MEMBER_ID;"
 			);
 		ResultSet rs=st.executeQuery();
 
 		while (rs.next()) {
 			Order order=new Order();
-			order.setId(rs.getInt("PROCEEDS_ID"));
 			order.setDate(rs.getString("DATE"));
 			order.setSimei(rs.getString("SIMEI"));
 			order.setCharge_id(rs.getString("CHARGE_ID"));

--- a/src/main/webapp/owner/orderstatus.jsp
+++ b/src/main/webapp/owner/orderstatus.jsp
@@ -22,7 +22,7 @@
 									<td>${order.name}</td>
 									<td>${order.price}</td>
 									<td>${order.count}</td>
-									<td><a href = "CartRemove.action">削除</a></td>
+									<td><a href = "">削除</a></td> <%-- リンク先実装予定：Remove.action --%>
 								</tr>
 							</table>
 						</c:forEach>


### PR DESCRIPTION
### 変更内容
売上DBのID列を削除した事に伴う、クエリの更新など影響範囲を変更。

### 背景
DBの概念設計で作成したER図を見直していたところ、
部分関数従属になっているテーブルがあったため、正規化をやり直した。
（売上げ日時が主キーになるため、売上げIDは元々無くても良かった。）