### PR TITLE
MySQLへ移行完了に伴うコメントアウトの解除

### DIFF
--- a/src/main/java/dao/MemberSearchDAO.java
+++ b/src/main/java/dao/MemberSearchDAO.java
@@ -24,11 +24,8 @@ public class MemberSearchDAO extends DAO {
 		while (rs.next()) {
 			member = new Member();
 			member.setId(rs.getInt("MEMBER_ID"));
-			/*
-			DBをMySQLへ変更に伴う一時的なコメントアウト
 			member.setCustomer_id(rs.getString("CUSTOMER_ID"));
 			member.setCard_id(rs.getString("CARD_ID"));
-			*/
 			member.setSimei(rs.getString("SIMEI"));
 		}
 


### PR DESCRIPTION
### 変更内容
MySQLへ移行完了に伴い、
会員認証DAOにあるコメントアウト解除

### 背景
MySQLで全ての機能の動作確認が取れたため