### PR TITLE
SQLクエリを小文字に変更

### DIFF
--- a/src/main/java/dao/MemberAddRegisterDAO.java
+++ b/src/main/java/dao/MemberAddRegisterDAO.java
@@ -16,17 +16,17 @@ public class MemberAddRegisterDAO extends DAO {
 			Connection con=getConnection();
 			con.setAutoCommit(false);
 
-			PreparedStatement st=con.prepareStatement("UPDATE MEMBER SET CUSTOMER_ID=?, CARD_ID=? WHERE MEMBER_ID=?");
+			PreparedStatement st=con.prepareStatement("update member set customer_id=?, card_id=? where member_id=?");
 			st.setString(1, customer.getId());	
 			st.setString(2, card.getId());
 			st.setInt(3, member.getId());
 			st.executeUpdate();
 
-			st=con.prepareStatement("SELECT * FROM MEMBER WHERE CUSTOMER_ID=?");
+			st=con.prepareStatement("select * from member where customer_id=?");
 			st.setString(1, customer.getId());
 			ResultSet rs=st.executeQuery();
 			while (rs.next()) {
-				member.setCustomer_id(rs.getString("CUSTOMER_ID"));
+				member.setCustomer_id(rs.getString("customer_id"));
 				line++;
 			}
 

--- a/src/main/java/dao/MemberRegisterDAO.java
+++ b/src/main/java/dao/MemberRegisterDAO.java
@@ -14,8 +14,8 @@ public class MemberRegisterDAO extends DAO {
 			Connection con=getConnection();
 			con.setAutoCommit(false);
 
-			PreparedStatement st=con.prepareStatement("INSERT INTO MEMBER (LOGIN, PASSWORD, SIMEI, FURIGANA, "
-					+ "MAIL, TEL, POSTCODE, PREFECTURE, CITY, ADDRESS) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+			PreparedStatement st=con.prepareStatement("insert into member (login, password, simei, furigana, "
+					+ "mail, tel, postcode, prefecture, city, address) value(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
 			st.setString(1, member.getLogin());
 			st.setString(2, member.getPassword());
 			st.setString(3, member.getSimei());
@@ -28,7 +28,7 @@ public class MemberRegisterDAO extends DAO {
 			st.setString(10, member.getAddress());
 			st.executeUpdate();
 
-			st=con.prepareStatement("SELECT * FROM MEMBER WHERE LOGIN=?");
+			st=con.prepareStatement("select * from member where login=?");
 			st.setString(1, member.getLogin());
 			ResultSet rs=st.executeQuery();
 			while (rs.next()) {

--- a/src/main/java/dao/MemberSearchDAO.java
+++ b/src/main/java/dao/MemberSearchDAO.java
@@ -16,17 +16,17 @@ public class MemberSearchDAO extends DAO {
 
 		PreparedStatement st;
 		st=con.prepareStatement(
-			"SELECT * FROM MEMBER WHERE LOGIN=? AND PASSWORD=?");
+			"select * from member where login=? and password=?");
 		st.setString(1, login);
 		st.setString(2, password);
 		ResultSet rs=st.executeQuery();
 
 		while (rs.next()) {
 			member = new Member();
-			member.setId(rs.getInt("MEMBER_ID"));
-			member.setCustomer_id(rs.getString("CUSTOMER_ID"));
-			member.setCard_id(rs.getString("CARD_ID"));
-			member.setSimei(rs.getString("SIMEI"));
+			member.setId(rs.getInt("member_id"));
+			member.setCustomer_id(rs.getString("customer_id"));
+			member.setCard_id(rs.getString("card_id"));
+			member.setSimei(rs.getString("simei"));
 		}
 
 		st.close();

--- a/src/main/java/dao/OrderDAO.java
+++ b/src/main/java/dao/OrderDAO.java
@@ -17,19 +17,22 @@ public class OrderDAO extends DAO {
 
 		PreparedStatement st;
 		st=con.prepareStatement(
-			"SELECT C.DATE, M.SIMEI, C.CHARGE_ID, C.TOTALPRICE, P.NAME, P.PRICE, O.COUNT FROM PROCEEDS AS C JOIN PURCHASE AS O ON C.CHARGE_ID = O.CHARGE_ID JOIN FARMPRODUCT AS P ON O.PRODUCT_ID = P.PRODUCT_ID JOIN MEMBER AS M ON C.MEMBER_ID = M.MEMBER_ID;"
+			"select c.date, m.simei, c.charge_id, c.totalprice, p.name, p.price, o.count "
+			+ "from proceeds as c join purchase as o on c.charge_id = o.charge_id"
+			+ " join farmproduct as p on o.product_id = p.product_id "
+			+ "join member as m on c.member_id = m.member_id;"
 			);
 		ResultSet rs=st.executeQuery();
 
 		while (rs.next()) {
 			Order order=new Order();
-			order.setDate(rs.getString("DATE"));
-			order.setSimei(rs.getString("SIMEI"));
-			order.setCharge_id(rs.getString("CHARGE_ID"));
-			order.setTotalprice(rs.getInt("TOTALPRICE"));
-			order.setName(rs.getString("NAME"));
-			order.setPrice(rs.getInt("PRICE"));
-			order.setCount(rs.getInt("COUNT"));
+			order.setDate(rs.getString("date"));
+			order.setSimei(rs.getString("simei"));
+			order.setCharge_id(rs.getString("charge_id"));
+			order.setTotalprice(rs.getInt("totalprice"));
+			order.setName(rs.getString("name"));
+			order.setPrice(rs.getInt("price"));
+			order.setCount(rs.getInt("count"));
 			orderlist.add(order);
 		}
 

--- a/src/main/java/dao/OwnerDAO.java
+++ b/src/main/java/dao/OwnerDAO.java
@@ -16,15 +16,15 @@ public class OwnerDAO extends DAO {
 
 		PreparedStatement st;
 		st=con.prepareStatement(
-			"SELECT * FROM OWNER WHERE LOGIN=? AND PASSWORD=?");
+			"select * from owner where login=? AND password=?");
 		st.setString(1, login);
 		st.setString(2, password);
 		ResultSet rs=st.executeQuery();
 
 		while (rs.next()) {
 			owner = new Owner();
-			owner.setId(rs.getInt("OWNER_ID"));
-			owner.setName(rs.getString("NAME"));
+			owner.setId(rs.getInt("owner_id"));
+			owner.setName(rs.getString("name"));
 		}
 
 		st.close();

--- a/src/main/java/dao/ProceedsDAO.java
+++ b/src/main/java/dao/ProceedsDAO.java
@@ -18,7 +18,7 @@ public class ProceedsDAO extends DAO {
 		String s = f.format(now);
 		
 		PreparedStatement st = con.prepareStatement(
-			"insert into proceeds (CHARGE_ID, DATE, MEMBER_ID, TOTALPRICE) values(?, ?, ?, ?)");
+			"insert into proceeds (charge_id, date, member_id, totalprice) values(?, ?, ?, ?)");
 		st.setString(1, charge.getId());
 		st.setString(2, s);
 		st.setInt(3, member.getId());

--- a/src/main/java/dao/ProductAddDAO.java
+++ b/src/main/java/dao/ProductAddDAO.java
@@ -11,10 +11,11 @@ public class ProductAddDAO extends DAO {
 		Connection con=getConnection();
 
 		PreparedStatement st=con.prepareStatement(
-			"INSERT INTO FARMPRODUCT (CATEGORY_ID, NAME, PRICE) VALUES(?, ?, ?)");
-		st.setInt(1, product.getId());
+			"insert into farmproduct (category_id, name, price, stock) value(?, ?, ?, ?)");
+		st.setInt(1, product.getKategoryId());
 		st.setString(2, product.getName());
 		st.setInt(3, product.getPrice());
+		st.setInt(4, product.getStock());
 		int line=st.executeUpdate();// DBの内容を変更するメソッド。変更された行数を返す。(p210)
 
 		st.close();

--- a/src/main/java/dao/ProductSearchDAO.java
+++ b/src/main/java/dao/ProductSearchDAO.java
@@ -16,7 +16,7 @@ public class ProductSearchDAO extends DAO {
 		Connection con=getConnection();
 
 		PreparedStatement st=con.prepareStatement(
-			"SELECT * FROM FARMPRODUCT WHERE NAME LIKE ? OR CATEGORY_ID=?");
+			"select * from farmproduct where name like ? or category_id=?");
 		st.setString(1, "%"+keyword+"%");
 		st.setInt(2, category);
 		ResultSet rs=st.executeQuery(); // DBの検索結果を取得するメソッド。結果はオブジェクトで返す。(p202)

--- a/src/main/java/dao/ProductStockRegisterDAO.java
+++ b/src/main/java/dao/ProductStockRegisterDAO.java
@@ -12,12 +12,12 @@ public class ProductStockRegisterDAO extends DAO {
 			Connection con = getConnection();
 			con.setAutoCommit(false);
 
-			PreparedStatement st = con.prepareStatement("UPDATE FARMPRODUCT SET STOCK=? WHERE PRODUCT_ID=?");
+			PreparedStatement st = con.prepareStatement("update farmproduct set stock=? where product_id=?");
 			st.setInt(1, recount);
 			st.setInt(2, id);
 			st.executeUpdate();
 
-			st = con.prepareStatement("SELECT * FROM FARMPRODUCT WHERE STOCK=? && PRODUCT_ID=?");
+			st = con.prepareStatement("select * from farmproduct where stock=? && product_id=?");
 			st.setInt(1, recount);
 			st.setInt(2, id);
 			ResultSet rs = st.executeQuery();

--- a/src/main/java/dao/PurchaseDAO.java
+++ b/src/main/java/dao/PurchaseDAO.java
@@ -15,7 +15,7 @@ public class PurchaseDAO extends DAO {
 		
 		for (Item item : cart) {
 			PreparedStatement st = con.prepareStatement(
-				"INSERT INTO PURCHASE (CHARGE_ID, PRODUCT_ID, COUNT) VALUES(?, ?, ?)");
+				"insert into purchase (charge_id, product_id, count) values(?, ?, ?)");
 			st.setString(1, charge.getId());
 			Product p = item.getProduct();
 			st.setInt(2, p.getId());

--- a/src/main/java/dao/StockDAO.java
+++ b/src/main/java/dao/StockDAO.java
@@ -19,7 +19,8 @@ public class StockDAO extends DAO {
 		PreparedStatement st;
 		st=con.prepareStatement(
 			// 人間が理解し易いよう、商品DBと品目DBを結合。品目ID列を品目名とした在庫リストを得る。
-			"select P.product_id, H.category_name, P.name, P.price, P.stock from farmproduct as P join category as H on P.category_id = H.category_id"
+			"select P.product_id, H.category_name, P.name, P.price, P.stock "
+			+ "from farmproduct as P join category as H on P.category_id = H.category_id"
 			);
 		ResultSet rs=st.executeQuery();
 


### PR DESCRIPTION
### 変更内容
今まではSQLクエリを全て大文字で記入してたが、全て小文字に変更した。

### 背景
デプロイ環境でMySQLがテーブルを認識してくれない問題が発生。
「基本的にMySQLは大文字小文字は関係なく認識する」
とChat-GPT先生より回答いただくも環境によっては認識されない場合があるとのことで、
試してみることにしたため。