### PR TITLE
MySQLドライバクラス名を最新版へ変更

### DIFF
--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -20,7 +20,7 @@ Serversのserver.xmlでも同様の設定ができるが、こっちの方が優
 		name="jdbc/mikan"
 		auth="Container"
 		type="javax.sql.DataSource"
-		driverClassName="com.mysql.jdbc.Driver"
+		driverClassName="com.mysql.cj.jdbc.Driver"
 		url="jdbc:mysql://localhost/MikanYama"
 		username="root"
 		password="8afdetSql"


### PR DESCRIPTION
### 変更内容
MySQLドライバクラス名を最新版へ変更。
初回接続時のパフォーマンスが少し向上。

### 背景
旧版のため、初回コネクションプール形成時に、
ネットワークから取り込んでいたようで一瞬もたつきがあったため。