### PR TITLE
DB接続の例外処理とリソース解放の見直し

### DIFF
--- a/src/main/java/dao/MemberRegisterDAO.java
+++ b/src/main/java/dao/MemberRegisterDAO.java
@@ -9,46 +9,78 @@ import bean.Member;
 public class MemberRegisterDAO extends DAO {
 	/***** 新規会員登録機能 *****/
 	public int r️egister(Member member) throws Exception {
-		int line=0;
-		try {
-			Connection con=getConnection();
-			con.setAutoCommit(false);
+		int line = 0;
+        Connection con = null;
+        PreparedStatement st = null;
+        ResultSet rs = null;
 
-			PreparedStatement st=con.prepareStatement("insert into member (login, password, simei, furigana, "
-					+ "mail, tel, postcode, prefecture, city, address) value(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
-			st.setString(1, member.getLogin());
-			st.setString(2, member.getPassword());
-			st.setString(3, member.getSimei());
-			st.setString(4, member.getFurigana());
-			st.setString(5, member.getMail());
-			st.setString(6, member.getTel());
-			st.setString(7, member.getPostcode());
-			st.setString(8, member.getPrefecture());
-			st.setString(9, member.getCity());
-			st.setString(10, member.getAddress());
-			st.executeUpdate();
+        try {
+            con = getConnection();
+            con.setAutoCommit(false);
 
-			st=con.prepareStatement("select * from member where login=?");
-			st.setString(1, member.getLogin());
-			ResultSet rs=st.executeQuery();
-			while (rs.next()) {
-				line++;
-			}
+            // インサートの準備と実行
+            st = con.prepareStatement("insert into member (login, password, simei, furigana, mail, tel, postcode, prefecture, city, address) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+            st.setString(1, member.getLogin());
+            st.setString(2, member.getPassword());
+            st.setString(3, member.getSimei());
+            st.setString(4, member.getFurigana());
+            st.setString(5, member.getMail());
+            st.setString(6, member.getTel());
+            st.setString(7, member.getPostcode());
+            st.setString(8, member.getPrefecture());
+            st.setString(9, member.getCity());
+            st.setString(10, member.getAddress());
+            st.executeUpdate();
+            st.close();
 
-			if (line == 1) {
-				con.commit();
-			} else {
-				con.rollback();
-			}
+            // インサート結果の確認
+            st = con.prepareStatement("select * from member where login = ?");
+            st.setString(1, member.getLogin());
+            rs = st.executeQuery();
+            while (rs.next()) {
+                line++;
+            }
 
-			con.setAutoCommit(true);
+            if (line == 1) {
+                con.commit();
+            } else {
+                con.rollback();
+            }
 
-			st.close();
-			con.close();
-		} catch (Exception e) {
-			e.printStackTrace();
-		}	
-		return line;
+            con.setAutoCommit(true);
+        } catch (Exception e) {
+            if (con != null) {
+                try {
+                    con.rollback();
+                } catch (Exception rollbackEx) {
+                    rollbackEx.printStackTrace();
+                }
+            }
+            e.printStackTrace();
+        } finally {
+            if (rs != null) {
+                try {
+                    rs.close();
+                } catch (Exception rsEx) {
+                    rsEx.printStackTrace();
+                }
+            }
+            if (st != null) {
+                try {
+                    st.close();
+                } catch (Exception stEx) {
+                    stEx.printStackTrace();
+                }
+            }
+            if (con != null) {
+                try {
+                    con.close();
+                } catch (Exception conEx) {
+                    conEx.printStackTrace();
+                }
+            }
+        }
+        return line;
 	}
 		
 }


### PR DESCRIPTION
### 変更内容
対象は会員登録用DAOのみ。
例外時のロールバック：例外が発生した場合にトランザクションをロールバックする処理を追加
PreparedStatementとResultSetのクローズ：PreparedStatementとResultSetもfinallyブロックでクローズするようにした。
リソースの安全なクローズ: クローズ処理時にnullチェックを行い、さらにクローズメソッド自体が例外を投げる可能性があるため、例外処理を追加した。

### 背景
コードをより堅牢にし、リソースリークや予期せぬ例外に対する耐性を向上するため。
