### PR TITLE
商品ページの在庫情報を個数表示に変更

### DIFF
--- a/src/main/java/dao/MemberRegisterDAO.java
+++ b/src/main/java/dao/MemberRegisterDAO.java
@@ -9,6 +9,7 @@ import bean.Member;
 public class MemberRegisterDAO extends DAO {
 	/***** 新規会員登録機能 *****/
 	public int r️egister(Member member) throws Exception {
+		// 変数の設定
 		int line = 0;
         Connection con = null;
         PreparedStatement st = null;
@@ -49,6 +50,7 @@ public class MemberRegisterDAO extends DAO {
 
             con.setAutoCommit(true);
         } catch (Exception e) {
+        	// ロールバック
             if (con != null) {
                 try {
                     con.rollback();
@@ -58,6 +60,7 @@ public class MemberRegisterDAO extends DAO {
             }
             e.printStackTrace();
         } finally {
+        	// リソースの解放
             if (rs != null) {
                 try {
                     rs.close();

--- a/src/main/java/shopping/CartAddAction.java
+++ b/src/main/java/shopping/CartAddAction.java
@@ -21,7 +21,7 @@ public class CartAddAction extends Action {
 		HttpSession session = request.getSession();
 		
 		int id = Integer.parseInt(request.getParameter("id"));  // 商品ID
-		int addQuantity = Integer.parseInt(request.getParameter("addQuantity"));  // カートへ追加の個数
+		int addQuantity = Integer.parseInt(request.getParameter("addQuantity"));  // カートへ追加の個数 
 		int totalPrice = 0; // 合計金額
 		int totalCount = 0; // 合計個数
 		int totalPrice_taxIn = 0; //税込み合計金額
@@ -32,12 +32,21 @@ public class CartAddAction extends Action {
 		if (cart == null) {
 			cart = new ArrayList<Item>();
 			session.setAttribute("CART", cart);
-		}	
+		}
 		// カート内に追加商品と同種商品が存在する場合は個数を更新し、newItemAdd_indicatorを"off"に設定
 		for (Item item : cart) {
 			if (item.getProduct().getId() == id) {
 				item.setCount(item.getCount() + addQuantity);
 				newItemAdd_indicator = "off";
+				
+				/* 在庫の更新
+				int stock = item.getProduct().getStock() - addQuantity;
+				ProductStockRegisterDAO psrdao = new ProductStockRegisterDAO();
+				int line = psrdao.r️egister(id, stock);
+				if (line != 1) {
+					return "stock-register-error.jsp";
+				}
+				*/
 				break;
 			}
 		}

--- a/src/main/webapp/shopping/product.jsp
+++ b/src/main/webapp/shopping/product.jsp
@@ -54,7 +54,16 @@
 								</tr>
 								<tr>
 									<td>商品${product.id}</td>
-									<td>${product.name}：${product.stock>0 ? "在庫あり" : "在庫なし"}</td>
+									<td>${product.name}</td>
+								</tr>
+								<tr>
+									<td>在庫</td>
+									<td>
+										<c:choose>
+											<c:when test="${product.stock>0}">${product.stock}個	</c:when>
+											<c:otherwise>在庫なし	</c:otherwise>
+										</c:choose>
+									</td>
 								</tr>
 								<tr>
 									<td>${product.price}円</td>


### PR DESCRIPTION
### 変更内容
以前は在庫の有り無しの２択表示だったが、ある場合を個数表示にした。

### 背景
購入可能数量が不明だった。但し、現時点ではカートへ投入後、
リアルタイムに商品ページの在庫数が減る機能は未実装。
購入確定後でないと繁栄されない仕様になっているため、随時実装を進める。