### PR TITLE
在庫ゼロ時の商品追加機能停止

### DIFF
--- a/src/main/java/shopping/ProductAction.java
+++ b/src/main/java/shopping/ProductAction.java
@@ -16,13 +16,14 @@ public class ProductAction extends Action {
 		) throws Exception {
 		
 		HttpSession session = request.getSession();
-		String keyword = request.getParameter("keyword");		
 		int category = 0;
-
+		
 		// 品目検索のリクエスト（"category" = 1〜4）が来た際は、プリミティブ型に変換
 		if (request.getParameter("category") != null) {
 			category = Integer.parseInt(request.getParameter("category"));
 		}
+		// キーワード検索で
+		String keyword = request.getParameter("keyword");
 		
 		// キーワードと品目ともにデフォルト値の場合に全商品を表示さすための設定
 		if (keyword == null && category == 0) keyword = "";

--- a/src/main/webapp/shopping/cart.jsp
+++ b/src/main/webapp/shopping/cart.jsp
@@ -22,7 +22,7 @@
 								</div>
 								<div class="btn-regi_or_con">
 									<p class="choice"><a href="Preview.action" class="btn btnBig register">レジに進む</a></p>
-									<p class="choice"><a href="product.jsp" class="btn btnBig continue">買い物を続ける</a></p>
+									<p class="choice"><a href="Product.action" class="btn btnBig continue">買い物を続ける</a></p>
 								</div>
 							</c:when>
 							<c:otherwise>

--- a/src/main/webapp/shopping/product.jsp
+++ b/src/main/webapp/shopping/product.jsp
@@ -68,17 +68,32 @@
 								<tr>
 									<td>${product.price}円</td>
 									<td>
-										<form action = "CartAdd.action" method = "post">
-											<input type="hidden" name="id" value="${product.id}">
-											<select name = "addQuantity">
-												<%-- 繰り返し回数の指定（SBC P341）--%>
-												<c:forEach var = "i" begin = "1" end = "20">
-													<option value = "${i}">${i}</option>
-												</c:forEach>
-											</select>
-											個
-											<input type = "submit" value = "カートに追加">
-										</form>
+										<c:choose>
+											<c:when test="${product.stock>0}">
+												<form action = "CartAdd.action" method = "post">
+													<input type="hidden" name="id" value="${product.id}">
+													<select name = "addQuantity">
+														<%-- 繰り返し回数の指定（SBC P341）--%>
+														<c:forEach var = "i" begin = "1" end = "20">
+															<option value = "${i}">${i}</option>
+														</c:forEach>
+													</select>
+													個
+													<input type = "submit" value = "カートに追加">
+												</form>	
+											</c:when>
+											<c:otherwise>
+												<form action = ""  method = "post">
+													<input type="hidden" name="id" value="${product.id}">
+													<select name = "addQuantity">
+														<option value="0">0&ensp;</option>
+													</select>
+													個
+													<input type = "submit" value = "カートに追加">
+												</form>
+											</c:otherwise>
+										</c:choose>
+										
 									</td>
 								</tr>
 							</table>


### PR DESCRIPTION
### 変更内容
在庫ゼロ時のカートへの追加機能停止と、個数セレクト欄をゼロのみ表示

### 背景
在庫ゼロでも個数の選択とカートへの追加が出来てしまう仕様の訂正