### PR TITLE
セッションを利用した在庫更新表示

### DIFF
--- a/src/main/webapp/shopping/cart.jsp
+++ b/src/main/webapp/shopping/cart.jsp
@@ -22,7 +22,7 @@
 								</div>
 								<div class="btn-regi_or_con">
 									<p class="choice"><a href="Preview.action" class="btn btnBig register">レジに進む</a></p>
-									<p class="choice"><a href="Product.action" class="btn btnBig continue">買い物を続ける</a></p>
+									<p class="choice"><a href="product.jsp" class="btn btnBig continue">買い物を続ける</a></p>
 								</div>
 							</c:when>
 							<c:otherwise>


### PR DESCRIPTION
### 変更内容
セッションの情報更新により、新しい在庫情報を画面に表示する様にした。
（商品DBでの在庫更新機能は以前から変更なし）

### 背景
商品の絞り込み検索後にカートに商品を追加した後、
引き続き検索結果画面から買い物が出来、且つ在庫情報も更新された画面を表示するため。