### PR TITLE
例外処理の見直し（Fコンと会員登録）

### DIFF
--- a/src/main/java/dao/MemberRegisterDAO.java
+++ b/src/main/java/dao/MemberRegisterDAO.java
@@ -58,7 +58,8 @@ public class MemberRegisterDAO extends DAO {
                     rollbackEx.printStackTrace();
                 }
             }
-            e.printStackTrace();
+            //e.printStackTrace();
+            throw e;  // 再スローすることでJVMは伝番（throws宣言）に処理を移す。
         } finally {
         	// リソースの解放
             if (rs != null) {
@@ -77,6 +78,8 @@ public class MemberRegisterDAO extends DAO {
             }
             if (con != null) {
                 try {
+                	// オートコミットをデフォルト状態に戻す
+                	con.setAutoCommit(true);
                     con.close();
                 } catch (Exception conEx) {
                     conEx.printStackTrace();

--- a/src/main/java/tool/FrontController.java
+++ b/src/main/java/tool/FrontController.java
@@ -1,7 +1,6 @@
 package tool;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -17,7 +16,7 @@ public class FrontController extends HttpServlet {
 	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 
 		response.setContentType("text/html; charset=UTF-8");
-		PrintWriter out=response.getWriter();
+		//PrintWriter out=response.getWriter();
 		
 		try {
 			// Fコントローラが呼び出されたパスを取得し、先頭一文字を除去（/chapter24/Login.action → chapter24/Login.action）			
@@ -30,13 +29,28 @@ public class FrontController extends HttpServlet {
 			String url = action.execute(request, response);
 			// 指定されたフォワード先（jspファイル）へフォワード
 			request.getRequestDispatcher(url).forward(request, response);
-		} catch (Exception e) {
-			e.printStackTrace(out);
-		}
+		} catch (ClassNotFoundException e) {
+            handleException(response, "Requested action not found.", e);
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException e) {
+            handleException(response, "Error creating action instance.", e);
+        } catch (Exception e) {
+            handleException(response, "An unexpected error occurred.", e);
+        }
 	}
+	
+	// 例外のハンドリング
+	private void handleException(HttpServletResponse response, String message, Exception e) throws IOException {
+        // ログに例外の詳細を記録（ここでは標準エラー出力に記録）
+        e.printStackTrace();
+        //e.printStackTrace(out); スタックトレースをクライアントへ直接出力（開発中のみ有用）
+        
+        // クライアントに対して簡潔なエラーメッセージを表示
+        response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, message);
+    }
 	
 	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 		doPost(request, response);
 		//doGetもdoPostを呼ぶ。よってGETリクエストもPOSTリクエストも同じ処理を行う。
 	}
+
 }


### PR DESCRIPTION
### 変更内容
（１）フロントコントローラ
・エラーログをデフォルトの表示先へ変更。クライアントサイドには簡潔な内容表示へ変更
・キャッチする例外種類を増やした。

（２）会員登録（MemberRegisterDAO.java）
例外伝番とfainallyブロックによる例外処理の強靭化に伴う微調整

### 背景
（１）開発用にクライアントサイドにスタックトレースを出力する仕様のままであった。
（２）一部不完全な例外処理があったため。