### PR TITLE
カートから削除時の在庫復活（Branch 22）

### DIFF
--- a/src/main/java/bean/Item.java
+++ b/src/main/java/bean/Item.java
@@ -1,21 +1,41 @@
 package bean;
 
 // 商品番号(id),商品名(name),価格(price)を属性に持つProduct型インスタンスを属性に持つItemクラス。
-public class Item implements java.io.Serializable{
+public class Item implements java.io.Serializable {
 	private Product product;
-	private int count;   // 商品の個数
-	
+	private int count; // 商品の個数
+
 	public Product getProduct() {
 		return product;
 	}
+
 	public int getCount() {
 		return count;
 	}
 
 	public void setProduct(Product product) {
-		this.product=product;
+		this.product = product;
 	}
+
 	public void setCount(int count) {
-		this.count=count;
+		this.count = count;
 	}
+
+	@Override
+	public boolean equals(Object o) {
+		if(o == this) return true;
+		if(o == null) return false;
+		if(!(o instanceof Item)) return false;
+		Item r = (Item) o;
+		if(this.product.getId() != r.product.getId()) {
+			return false;
+		}
+		return true;
+	}
+	
+	@Override
+	public int hashCode() {
+		return product != null ? product.getId() : 0;
+	}
+
 }

--- a/src/main/java/shopping/CartAddAction.java
+++ b/src/main/java/shopping/CartAddAction.java
@@ -10,53 +10,50 @@ import bean.Item;
 import bean.Product;
 import dao.ProductStockRegisterDAO;
 import tool.Action;
-// カートの準備とカートへの商品追加および各種合計データの計算
+// カートへの商品追加および各種合計データの計算
 public class CartAddAction extends Action {
 	@SuppressWarnings("unchecked")
 	public String execute(HttpServletRequest request) throws Exception {
 		
-		// 商品(Bean)を格納するカート(List)や検索商品リストをセッションスコープから取得
+		// 各種情報取得と設定
 		HttpSession session = request.getSession();
 		List<Product> list = (List<Product>)session.getAttribute("LIST");  //商品リスト
-		List<Item> cart = (List<Item>)session.getAttribute("CART");
-		
-		// 追加商品等の情報取得と設定
+		List<Item> cart = (List<Item>)session.getAttribute("CART");  // 商品カート
 		int id = Integer.parseInt(request.getParameter("id"));  // 商品ID
-		int addQuantity = Integer.parseInt(request.getParameter("addQuantity"));  // カートへ追加の個数 
+		int addQuantity = Integer.parseInt(request.getParameter("addQuantity"));  // 追加商品の個数
 		int totalPrice = 0; // 合計金額
 		int totalCount = 0; // 合計個数
 		int totalPrice_taxIn = 0; //税込み合計金額
-		String newItemAdd_indicator = "on";
-		// 追加商品がカート内に既存するかどうかの指標(デフォルト値の"on"は既存しない新たな商品を追加することを示す)
-				
+		String newItemAdd_indicator = "on";  // onはカート内に既存しない種類の商品追加を示す指標
+					
 		if (cart == null) {
 			cart = new ArrayList<Item>();
+			session.setAttribute("CART", cart);
 		}
 		
-		// カート内に追加商品と同種商品が存在する場合は個数を更新し、newItemAdd_indicatorを"off"に設定
+		// カート内に追加商品と同種商品が存在する場合
 		for (Item item : cart) {
 			if (item.getProduct().getId() == id) {
+				
+				// 購入商品の個数更新
 				item.setCount(item.getCount() + addQuantity);
 				newItemAdd_indicator = "off";
 				
-				// 商品DBの在庫の更新
+				// 商品DBの在庫更新
 				int stock = item.getProduct().getStock() - addQuantity;
 				ProductStockRegisterDAO psrdao = new ProductStockRegisterDAO();
 				int line = psrdao.r️egister(id, stock);
-				if (line != 1) {
-					return "stock-register-error.jsp";
-				}
+				if (line != 1) return "stock-register-error.jsp";
 				
-				// 商品リストの在庫表示の更新（セッションスコープの商品在庫の更新）
+				// セッションに保存中の商品（リスト）の在庫更新
 				item.getProduct().setStock(stock);
-				System.out.println("同種" + item.getProduct().getStock());
-				
-				
+				// 動作確認用コード
+				System.out.println("同種商品「" + item.getProduct().getName() + "」の追加。在庫は「" + item.getProduct().getStock() + "個」に減少。");
 				break;
 			}
 		}
 		
-		// カート内に同種商品が存在していない場合は新たに商品情報を追加
+		// カート内に追加商品が存在していない場合（新規追加）
 		if(newItemAdd_indicator == "on") {
 			for (Product p : list) {
 				if (p.getId() == id) {
@@ -64,17 +61,15 @@ public class CartAddAction extends Action {
 					item.setProduct(p);
 					item.setCount(addQuantity);
 					
-					// 商品DBの在庫の更新
+					// 商品DBの在庫更新
 					int stock = p.getStock() - addQuantity;
 					ProductStockRegisterDAO psrdao = new ProductStockRegisterDAO();
 					int line = psrdao.r️egister(id, stock);
-					if (line != 1) {
-						return "stock-register-error.jsp";
-					}
+					if (line != 1) return "stock-register-error.jsp";
 					
-					// 商品リストの在庫表示の更新（セッションスコープの商品在庫の更新）
+					// セッションに保存中の商品（リスト）の在庫更新
 					p.setStock(stock);
-					System.out.println("新規" + p.getStock());
+					System.out.println("新規商品「" + p.getName() + "」の追加。在庫は「" + p.getStock() + "個」に減少。");
 					
 					cart.add(item);
 					break;
@@ -82,19 +77,17 @@ public class CartAddAction extends Action {
      		}
 		}
 		
-		// カート内の合計個数と金額の計算		
+		// カート内の合計個数と金額の計算	
 		for (Item item : cart) {
 			totalPrice += item.getProduct().getPrice() * item.getCount();
 			totalCount += item.getCount();
 		}
 		
-		// 税込み合計金額計算と各種合計情報のセッションスコープへの格納
+		// 計算結果のセッションスコープへの格納
 		totalPrice_taxIn = (int)(totalPrice * 1.1);
 		session.setAttribute("TOTALPRICE_TAXIN", totalPrice_taxIn);
 		session.setAttribute("TOTALPRICE", totalPrice);
 		session.setAttribute("TOTALCOUNT", totalCount);
-		session.setAttribute("LIST", list);
-		session.setAttribute("CART", cart);
 		return "cart.jsp";	
 	}
 }

--- a/src/main/java/shopping/CartRemoveAction.java
+++ b/src/main/java/shopping/CartRemoveAction.java
@@ -6,6 +6,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 import bean.Item;
+import dao.ProductStockRegisterDAO;
 import tool.Action;
 //カート内の商品削除に伴う各種合計データの更新
 public class CartRemoveAction extends Action {
@@ -29,7 +30,17 @@ public class CartRemoveAction extends Action {
 				session.setAttribute("TOTALPRICE_TAXIN", totalPrice_taxIn);
 				session.setAttribute("TOTALPRICE", totalPrice);
 				session.setAttribute("TOTALCOUNT", totalCount);
-				// カートから商品を削除
+				
+				// 商品DBの在庫の更新
+				int stock = item.getProduct().getStock() + item.getCount();
+				ProductStockRegisterDAO psrdao = new ProductStockRegisterDAO();
+				int line = psrdao.r️egister(id, stock);
+				if (line != 1) return "stock-register-error.jsp";
+				
+				// セッションに保存中の商品（リスト）の在庫更新
+				item.getProduct().setStock(stock);
+				System.out.println("「" + item.getProduct().getName() + "」を削除。在庫が「" + item.getProduct().getStock() + "個」に復活。");
+				
 				cart.remove(item);
 				break;
 			}

--- a/src/main/java/tool/GetCookies.java
+++ b/src/main/java/tool/GetCookies.java
@@ -1,0 +1,49 @@
+package tool;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/tool/getcookies")
+public class GetCookies extends HttpServlet {
+	private static final long serialVersionUID = 1L;
+       
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		response.setContentType("text/html; charset=UTF-8");
+		PrintWriter out=response.getWriter();
+		out.println("<!DOCTYPE html>");
+		out.println("<html>");
+		out.println("<head>");
+		out.println("<meta charset='UTF-8'>");
+		out.println("<title>Get Cookies</title>");
+		out.println("</head>");
+		out.println("<body>");
+		
+		// クッキーの取得
+		Cookie[] cookies=request.getCookies();
+		
+		/* 各クッキーの取り出しとクライアントサイドへの表示
+		 * セッションを使うプログラムを実行した後ならば、
+		 * セッションIDを保持するクッキーも表示されることがある。
+		 */
+		if (cookies!=null) {
+			for (Cookie cookie : cookies) {
+				String name=cookie.getName();
+				String value=cookie.getValue();
+				out.println("<p>"+name+" : "+value+"</p>");
+			}
+		} else {
+			out.println("クッキーは存在しません");
+		}
+
+		out.println("</body>");
+		out.println("</html>");
+	}
+
+}

--- a/src/main/webapp/owner/login-out_owner.jsp
+++ b/src/main/webapp/owner/login-out_owner.jsp
@@ -6,7 +6,7 @@
         <div class="container">
             <div class="heading">
              	<c:if test="${OWNER.name!=null}">
-	             	<h2>Operation Manager Site</h2>
+	             	<h2>Owner's site home</h2>
 	             	<p>Hello! ${OWNER.name}さん。</p>
          		</c:if>
          		<br>

--- a/src/main/webapp/owner/login-owner.jsp
+++ b/src/main/webapp/owner/login-owner.jsp
@@ -4,9 +4,11 @@
         <div id="login-wrapper">
             <div class="container">
                 <div class="heading">
-                	<h2>Owner Login</h2>
+                	<h2>Owner's Site Entrance</h2>
                 	<br>
 					<p class="translation"><a href = "Loginowner.action">オーナーHOMEへ</a></p>
+					<br>
+					<h2>Owner Login</h2>
                 	<form action="Loginowner.action" method="post">
 						<p>ログイン名</p><input type="text" name="login" class="text">
 						<p>パスワード</p><input type="password" name="password" class="password">

--- a/src/main/webapp/shopping/product.jsp
+++ b/src/main/webapp/shopping/product.jsp
@@ -92,7 +92,7 @@
 												<%-- 空白を示す文字エンティティ：&ensp; --%>
 												<option value="0">0&ensp;</option>
 											</select>
-											<button type="button" disabled aria-disabled="true" title="欠品中">カートに追加</button>
+											<button type="button" disabled aria-disabled="true" title="欠品中">入荷待ち</button>
 										</div>
 									</c:otherwise>
 								</c:choose>


### PR DESCRIPTION
### 変更内容
カート削除と同時に商品在庫DBを更新するよう、各種プロセスを追加した。

### 背景
買い物中にカートから任意の商品を削除した際、商品在庫が戻らない仕様だったため。