### PR TITLE
消費税内訳の明示廃止（branch_24）

### DIFF
--- a/src/main/java/shopping/CartAddAction.java
+++ b/src/main/java/shopping/CartAddAction.java
@@ -10,20 +10,18 @@ import bean.Item;
 import bean.Product;
 import dao.ProductStockRegisterDAO;
 import tool.Action;
-// カートへの商品追加および各種合計データの計算
+// カートへ商品を追加するクラス
 public class CartAddAction extends Action {
 	@SuppressWarnings("unchecked")
 	public String execute(HttpServletRequest request) throws Exception {
 		
-		// 各種情報取得と設定
 		HttpSession session = request.getSession();
 		List<Product> list = (List<Product>)session.getAttribute("LIST");  //商品リスト
 		List<Item> cart = (List<Item>)session.getAttribute("CART");  // 商品カート
 		int id = Integer.parseInt(request.getParameter("id"));  // 商品ID
 		int addQuantity = Integer.parseInt(request.getParameter("addQuantity"));  // 追加商品の個数
-		int totalPrice = 0; // 合計金額
+		int totalPrice_taxIn = 0; //合計金額（税込）
 		int totalCount = 0; // 合計個数
-		int totalPrice_taxIn = 0; //税込み合計金額
 		String newItemAdd_indicator = "on";  // onはカート内に既存しない種類の商品追加を示す指標
 					
 		if (cart == null) {
@@ -82,14 +80,12 @@ public class CartAddAction extends Action {
 		
 		// カート内の合計個数と金額の計算	
 		for (Item item : cart) {
-			totalPrice += item.getProduct().getPrice() * item.getCount();
+			totalPrice_taxIn += (int)(item.getProduct().getPrice() * item.getCount() * 1.1);
 			totalCount += item.getCount();
 		}
 		
 		// 計算結果のセッションスコープへの格納
-		totalPrice_taxIn = (int)(totalPrice * 1.1);
 		session.setAttribute("TOTALPRICE_TAXIN", totalPrice_taxIn);
-		session.setAttribute("TOTALPRICE", totalPrice);
 		session.setAttribute("TOTALCOUNT", totalCount);
 		return "cart.jsp";	
 	}

--- a/src/main/java/shopping/CartRecountAction.java
+++ b/src/main/java/shopping/CartRecountAction.java
@@ -8,28 +8,24 @@ import javax.servlet.http.HttpSession;
 import bean.Item;
 import dao.ProductStockRegisterDAO;
 import tool.Action;
-// カート内での数量変更に伴う各種合計データの更新
+// カート内商品の数量変更を行うクラス
 public class CartRecountAction extends Action {
 	@SuppressWarnings("unchecked")
 	public String execute(HttpServletRequest request) throws Exception {
 		
 		HttpSession session = request.getSession();
-		// 数量変更する商品IDを取得
-		int id = Integer.parseInt(request.getParameter("id"));
-		// 数量変更する商品数量を取得
-		int recount = Integer.parseInt(request.getParameter("recount"));
-		// 商品を格納するカートの取得
-		List<Item> cart = (List<Item>)session.getAttribute("CART");
-		// 現在の合計金額と個数の取得
-		int totalPrice = (int)session.getAttribute("TOTALPRICE");
-		int totalCount = (int)session.getAttribute("TOTALCOUNT");
+		int id = Integer.parseInt(request.getParameter("id")); // 商品ID
+		int recount = Integer.parseInt(request.getParameter("recount")); // 変更数量
+		List<Item> cart = (List<Item>)session.getAttribute("CART"); // 商品カート
+		int totalPrice_taxIn = (int)session.getAttribute("TOTALPRICE_TAXIN"); // 合計金額（税込）
+		int totalCount = (int)session.getAttribute("TOTALCOUNT"); // 合計個数
 		
 		for (Item item : cart) {
 			if (item.getProduct().getId() == id) {
 				// 数量増加時
 				if(item.getCount() < recount) {
 					int incrementCount = recount - item.getCount();  // 増加個数
-					totalPrice += item.getProduct().getPrice() * incrementCount;
+					totalPrice_taxIn += (int)(item.getProduct().getPrice() * incrementCount * 1.1);
 					totalCount += incrementCount;
 					// カート内商品の個数の更新（"CART"の要素）					
 					item.setCount(recount);
@@ -49,7 +45,7 @@ public class CartRecountAction extends Action {
 				// 数量減少時
 				}else if(item.getCount() > recount){
 					int decrementCount = item.getCount() - recount;  // 減少個数
-					totalPrice -= item.getProduct().getPrice() * decrementCount;
+					totalPrice_taxIn -= (int)(item.getProduct().getPrice() * decrementCount * 1.1);
 					totalCount -= decrementCount;
 					// カート内商品の個数の更新（"CART"の要素）
 					item.setCount(recount);
@@ -71,9 +67,7 @@ public class CartRecountAction extends Action {
 				}
 				
 				// 税込み合計金額を再計算し、各種合計データをスコープへ再格納
-				int totalPrice_taxIn = (int)(totalPrice * 1.1);
 				session.setAttribute("TOTALPRICE_TAXIN", totalPrice_taxIn);
-				session.setAttribute("TOTALPRICE", totalPrice);
 				session.setAttribute("TOTALCOUNT", totalCount);
 				break;
 			}

--- a/src/main/java/shopping/CartRemoveAction.java
+++ b/src/main/java/shopping/CartRemoveAction.java
@@ -8,27 +8,24 @@ import javax.servlet.http.HttpSession;
 import bean.Item;
 import dao.ProductStockRegisterDAO;
 import tool.Action;
-//カート内の商品削除に伴う各種合計データの更新
+//カート内の商品を削除するクラス
 public class CartRemoveAction extends Action {
 	@SuppressWarnings("unchecked")
 	public String execute(HttpServletRequest request) throws Exception {
 		
 		HttpSession session = request.getSession();
-		int id = Integer.parseInt(request.getParameter("id"));  // 削除商品のID取得
-		int totalPrice = (int)session.getAttribute("TOTALPRICE"); // 現在の合計金額取得
-		int totalCount = (int)session.getAttribute("TOTALCOUNT"); // 現在の合計個数取得
-		int totalPrice_taxIn = (int)session.getAttribute("TOTALPRICE_TAXIN"); // 現在の税込合計金額取得
-		List<Item> cart = (List<Item>)session.getAttribute("CART"); // 商品カート取得
+		int id = Integer.parseInt(request.getParameter("id"));  // 商品ID
+		int totalPrice_taxIn = (int)session.getAttribute("TOTALPRICE_TAXIN"); // 合計金額（税込）	
+		int totalCount = (int)session.getAttribute("TOTALCOUNT"); // 合計個数
+		List<Item> cart = (List<Item>)session.getAttribute("CART"); // 商品カート
 		
 		for (Item item : cart) {
 			if (item.getProduct().getId() == id) {
 				// カート内の合計個数と金額を再計算
-				totalPrice -= item.getProduct().getPrice() * item.getCount();
+				totalPrice_taxIn -= (int)(item.getProduct().getPrice() * item.getCount() * 1.1);
 				totalCount -= item.getCount();
-				// 税込み合計金額を計算し、各更新情報をセッションスコープへ格納
-				totalPrice_taxIn = (int)(totalPrice * 1.1);
+				// セッションスコープへ格納
 				session.setAttribute("TOTALPRICE_TAXIN", totalPrice_taxIn);
-				session.setAttribute("TOTALPRICE", totalPrice);
 				session.setAttribute("TOTALCOUNT", totalCount);
 				
 				// 商品DBの在庫の更新

--- a/src/main/webapp/shopping/cart.jsp
+++ b/src/main/webapp/shopping/cart.jsp
@@ -17,7 +17,7 @@
 									<p class="total">合計${TOTALCOUNT}個（${CART.size()}種類）</p>
 									<p>
 										<strong  class="totalPrice">¥${TOTALPRICE_TAXIN}</strong>
-										<span class="tax">（内消費税¥${TOTALPRICE_TAXIN - TOTALPRICE}）</span>
+										<span class="tax">（税込）</span>
 									</p>
 								</div>
 								<div class="btn-regi_or_con">


### PR DESCRIPTION
合計金額（税込）のみの表示とした。
コード量を減らすことで可読性を高めるため。