### PR TITLE
排他制御とダブルチェックロッキング（Branch 28）

### DIFF
--- a/src/main/java/dao/DAO.java
+++ b/src/main/java/dao/DAO.java
@@ -8,16 +8,20 @@ import javax.naming.NamingException;
 import javax.sql.DataSource;
 // コネクションオブジェクト（プール）の取得機能
 public class DAO {
+	
 	private static DataSource ds; // 各DAOインスタンスで共有
 	private static final String JNDI_NAME = "java:/comp/env/jdbc/mikan"; // JNDI 名を定数化
-	// ダブルチェックロッキングやクラスレベルのロックにより、dsの初期化を確実に1回だけにする。
+	/* 
+	 * ダブルチェックロッキングやクラスレベルのロックにより、dsの初期化を確実に1回だけにする。
+	 * ダブルチェックにより、初期化が済んだ後は、ほとんどの呼び出しで synchronized に入らずに済むため高速。
+	*/
 	public Connection getConnection() throws SQLException {
 		// ①スレッドAとBが同時通過の可能性あり
 		if (ds == null) {
 			// ②ここで排他制御（クラスレベルでロック。マルチスレッドによる多数のds生成を防止）
 			synchronized (DAO.class) {
 				// ③スレッドAが先に入るとスレッドBは必ずfalseになるため最初のスレッドしか進めない
-				if (ds == null) {
+				if (ds == null) { // 2回目のチェック。スレッドBが後で入ってもAが初期化済みのため、再初期化が防止できる。
 					try {
 						InitialContext ic = new InitialContext();
 						ds = (DataSource) ic.lookup(JNDI_NAME); // データソース取得：P197参照

--- a/src/main/java/dao/ProductSearchDAO.java
+++ b/src/main/java/dao/ProductSearchDAO.java
@@ -13,7 +13,7 @@ public class ProductSearchDAO extends DAO {
 	public List<Product> search(int category, String keyword) throws Exception {
 		List<Product> list=new ArrayList<>();
 
-		Connection con=getConnection();
+		Connection con=getConnection(); // コネクションオブジェクト（プール）の取得
 
 		PreparedStatement st=con.prepareStatement(
 			"select * from farmproduct where name like ? or category_id=?");


### PR DESCRIPTION
### 変更内容
設計意図に関するコメントの追加
（データソース初期化時の排他制御とダブルチェックロッキング）

### 背景
久々に自分の書いたコードを振り返ってみると意図を理解するのに時間がかかったため。
