### PR TITLE
論理エラーの解消（カート内個数）

### DIFF
--- a/src/main/webapp/shopping/cart.jsp
+++ b/src/main/webapp/shopping/cart.jsp
@@ -44,7 +44,8 @@
 											数量:
 											<select name = "recount" class="recount">
 											<%-- 三項演算子(p324)とSelected属性により、ページ読み込み時点での選択個数を予め表示 --%>
-												<c:forEach var = "i" begin = "1" end = "20">
+												<c:set var="maxCount" value="${item.count > 20 ? item.count : 20}" />
+												<c:forEach var = "i" begin = "1" end = "${maxCount}">
 													<option value = "${i}" ${item.count == i ? "selected = \"selected\"" : ""}>${i}</option>
 												</c:forEach>
 											</select>


### PR DESCRIPTION
### 変更内容
カート内の各商品個数を表示していたセレクトボックスの上限が、カートに追加された個数に応じて動的に拡張するようにした。

### 背景
カート画面で各商品が20個を超えると1個に戻っていた。また、20個以内ならカート内で個数の変更が出来たが、20個を超えると20個以下に減らすリクエストしかできなかった。今回の変更で20個を超えても、追加した個数範囲内でカート画面から個数を変更（減らすのみ。それ以上に加算する場合は商品一覧ページから追加の必要がある）出来るようにした。